### PR TITLE
Use ctx.clearRect to mask pixels instead of reading the buffer and manually iterating

### DIFF
--- a/src/utils/renderSquares.ts
+++ b/src/utils/renderSquares.ts
@@ -124,13 +124,13 @@ const createTemplateBitmap = async (
     ctx.imageSmoothingEnabled = false;
 
     ctx.drawImage(imageBitmap, 0, 0, canvas.width, canvas.height);
-    for (let row = 0; row < canvas.height; row++) {
-        if (row % 3 == 1) continue;
-        ctx.clearRect(0, row, canvas.width, 1);
+    // Needs to start running from -3 because it deletes the bottom pixels for the current row, as well as the top pixels for the next one. This way we don't miss the topmost row of pixels
+    for (let row = -3; row < canvas.height; row += 3) {
+        ctx.clearRect(0, row + 2, canvas.width, 2);
     }
-    for (let col = 0; col < canvas.height; col++) {
-        if (col % 3 == 1) continue;
-        ctx.clearRect(col, 0, 1, canvas.height);
+    // Needs to start running from -3 because it deletes the right pixels for the current column, as well as the left pixels for the next one. This way we don't miss the leftmost column of pixels
+    for (let col = -3; col < canvas.height; col += 3) {
+        ctx.clearRect(col + 2, 0, 2, canvas.height);
     }
     const bitmap = createImageBitmap(canvas);
     canvas.remove();


### PR DESCRIPTION
Adjusts the `createTemplateBitmap` function to minimise rendering done on the CPU.

I've moved the pixel filtering logic to a separate step that operates at original scale, and refactored the upscaling and rendering logic so it doesn't require a GPU readback. Instead of clearing individual pixels, I used [`clearRect`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clearRect) to delete entire rows and columns at a time

On my machine this change caused `renderSquares` to execute in <500ms when filtering is disabled and ~1000ms when filtering is enabled, compared to the original function taking about 3000ms in total.