### PR TITLE
Fix image colour list not updating on edit

### DIFF
--- a/src/pages/Edit.tsx
+++ b/src/pages/Edit.tsx
@@ -205,7 +205,7 @@ export const Edit: FC = () => {
                                           image,
                                           height,
                                           width,
-                                          imageColors,
+                                          templateColors: imageColors!,
                                       }
                                     : {})(),
 


### PR DESCRIPTION
When updating the template image via Edit -> Change Template Image, currently the colour list doesn't get updated.

As far as I can tell, the issue is that instead of updating the correct `templateColors` field on update, the `imageColors` field gets created instead.