### PR TITLE
More caching and fixes

### DIFF
--- a/src/components/OverlayList/OverlayListEntry.tsx
+++ b/src/components/OverlayList/OverlayListEntry.tsx
@@ -47,9 +47,9 @@ export const OverlayListEntry: FC<{
                 <button
                     onClick={async () => {
                         window.postMessage({
-                            source: "overlay-location-service",
                             chunk,
                             position: [position[0] + width / 2, position[1] + height / 2],
+                            source: "overlay-jump-to",
                         });
                         await sleep(200);
                         awaitElement("button[title='Explore']").then((button) => {

--- a/src/components/OverlayList/OverlayListEntry.tsx
+++ b/src/components/OverlayList/OverlayListEntry.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useRef } from "react";
 import { useNavigate } from "../Router/navigate";
 import { awaitElement } from "../../utils/awaitElement";
+import { sleep } from "../../utils/sleep";
 import { EyeClosedIcon, EyeIcon, GearIcon, MapPinIcon } from "@phosphor-icons/react";
 
 export const OverlayListEntry: FC<{
@@ -44,12 +45,13 @@ export const OverlayListEntry: FC<{
                     <GearIcon />
                 </button>
                 <button
-                    onClick={() => {
+                    onClick={async () => {
                         window.postMessage({
                             source: "overlay-location-service",
                             chunk,
                             position: [position[0] + width / 2, position[1] + height / 2],
                         });
+                        await sleep(200);
                         awaitElement("button[title='Explore']").then((button) => {
                             button.dispatchEvent(
                                 new Event("click", { bubbles: true, cancelable: true }),

--- a/src/components/OverlayList/OverlayListEntry.tsx
+++ b/src/components/OverlayList/OverlayListEntry.tsx
@@ -47,9 +47,12 @@ export const OverlayListEntry: FC<{
                 <button
                     onClick={async () => {
                         window.postMessage({
-                            chunk,
-                            position: [position[0] + width / 2, position[1] + height / 2],
                             source: "overlay-jump-to",
+                            chunk: { x: chunk[0], y: chunk[1] },
+                            position: {
+                                x: position[0] + Math.trunc(width / 2),
+                                y: position[1] + Math.trunc(height / 2),
+                            },
                         });
                         await sleep(200);
                         awaitElement("button[title='Explore']").then((button) => {

--- a/src/fetchHook.ts
+++ b/src/fetchHook.ts
@@ -1,0 +1,135 @@
+import { inject } from "./utils/inject";
+import { CachedTile } from "./utils/renderSquares";
+
+export type TemplateManagerData = {
+    tilesCache: Map<number, CachedTile>;
+    jumpTo: {
+        pixel: { x: number; y: number } | null;
+        tile: { x: number; y: number } | null;
+    };
+    pixelUrlRegex: RegExp;
+    filesUrlRegex: RegExp;
+    randomTileUrlRegex: RegExp;
+};
+
+inject(() => {
+    console.log("injecting fetchHook...");
+
+    const sharedData: TemplateManagerData = {
+        tilesCache: new Map<number, CachedTile>(),
+        jumpTo: {
+            pixel: null,
+            tile: null,
+        },
+        pixelUrlRegex: new RegExp(
+            "^https://backend\\.wplace\\.live/s\\d+/pixel/(\\d+)/(\\d+)\\?x=(\\d+)&y=(\\d+)$",
+        ),
+        filesUrlRegex: new RegExp(
+            "^https://backend\\.wplace\\.live/files/s\\d+/tiles/(\\d+)/(\\d+)\\.png$",
+        ),
+        randomTileUrlRegex: new RegExp("^https://backend\\.wplace\\.live/s\\d+/tile/random$"),
+    };
+
+    // @ts-ignore
+    window.templateManagerData = sharedData;
+
+    window.addEventListener("message", (event: MessageEvent) => {
+        const { source, chunk, position } = event.data || {};
+        if (source === "overlay-jump-to") {
+            console.log(event.data);
+            sharedData.jumpTo.pixel = position;
+            sharedData.jumpTo.tile = chunk;
+            event.preventDefault();
+        }
+    });
+
+    const originalFetch = window.fetch;
+    window.fetch = async function (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+    ): Promise<Response> {
+        const request = new Request(input, init);
+
+        if (sharedData.randomTileUrlRegex.test(request.url)) {
+            console.log("randomTile request called");
+            if (sharedData.jumpTo.pixel && sharedData.jumpTo.tile) {
+                console.log("randomTile request changed to", sharedData.jumpTo);
+                const jumpResponse = new Response(JSON.stringify(sharedData.jumpTo), {
+                    headers: { "Content-Type": "application/json" },
+                });
+                sharedData.jumpTo.pixel = null;
+                sharedData.jumpTo.tile = null;
+                return jumpResponse;
+            }
+        } else if (sharedData.pixelUrlRegex.test(request.url)) {
+            const m = sharedData.pixelUrlRegex.exec(request.url);
+            if (m) {
+                const [, chunkX, chunkY, positionX, positionY] = m;
+                const chunk = { x: parseInt(chunkX, 10), y: parseInt(chunkY, 10) };
+                const position = { x: parseInt(positionX, 10), y: parseInt(positionY, 10) };
+                console.log("pixel request called at", { chunk, position });
+                window.postMessage({
+                    source: "overlay-setPosition",
+                    chunk,
+                    position,
+                });
+            }
+        }
+
+        const response = await originalFetch.call(window, request);
+
+        if (response.ok && sharedData.filesUrlRegex.test(request.url)) {
+            const m = sharedData.filesUrlRegex.exec(request.url);
+            if (m) {
+                const [, chunkX, chunkY] = m;
+                const origBlob = await response.blob();
+                const chunk = { x: parseInt(chunkX, 10), y: parseInt(chunkY, 10) };
+                console.log("tile image request called at", chunk);
+
+                let etag = response.headers.get("etag");
+                // currently there is a misconfiguration in the backend which doesn't allow us to get the response headers
+                if (!etag) {
+                    const buffer = await origBlob.arrayBuffer();
+                    const hashBuffer = await crypto.subtle.digest("SHA-1", buffer);
+                    const hashBytes = new Uint8Array(hashBuffer);
+                    etag = "";
+                    for (let i = 0; i < hashBytes.length; i++) {
+                        etag += hashBytes[i].toString(16).padStart(2, "0");
+                    }
+                }
+
+                const overlayBlob = await new Promise<Blob>((resolve) => {
+                    const requestId = Math.random().toString();
+                    const handleResponse = (event: Event) => {
+                        const customEvent = event as CustomEvent;
+                        if (customEvent.detail.requestId === requestId) {
+                            window.removeEventListener("overlay-render-response", handleResponse);
+                            resolve(customEvent.detail.blob);
+                        }
+                    };
+                    window.addEventListener("overlay-render-response", handleResponse);
+                    window.dispatchEvent(
+                        new CustomEvent("overlay-render-request", {
+                            detail: {
+                                requestId,
+                                tilesCache: sharedData.tilesCache,
+                                blob: origBlob,
+                                etag,
+                                chunk,
+                            },
+                        }),
+                    );
+                });
+                return new Response(overlayBlob, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers,
+                });
+            }
+        }
+
+        return response;
+    };
+
+    console.log("injected fetchHook!");
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { addLocationChangeCallback } from "./utils/addLocationChangeCallback";
 import { log } from "./utils/log";
 import { awaitElement } from "./utils/awaitElement";
 import App from "./App";
+import "./fetchHook";
 
 log("wplace.live Template Manager successfully loaded.");
 

--- a/src/utils/inject.ts
+++ b/src/utils/inject.ts
@@ -1,0 +1,6 @@
+export function inject(callback: () => void) {
+    const script = document.createElement("script");
+    script.textContent = `(${callback})();`;
+    document.documentElement?.appendChild(script);
+    // script.remove();
+}

--- a/src/utils/renderSquares.ts
+++ b/src/utils/renderSquares.ts
@@ -4,11 +4,18 @@ import { ColorValue, FreeColor, FreeColorMap, PaidColor, PaidColorMap } from "..
 import { rgbToHex } from "./rgbToHex";
 import { CustomCanvas } from "./CustomCanvas";
 
+export type CachedTile = {
+    blob: Blob;
+    baseBlobEtag: string;
+    overlaysHash: string;
+};
+
 export async function renderSquares(
-    baseBlob: Blob,
     overlays: Overlay[],
-    chunkX: number,
-    chunkY: number,
+    tilesCache: Map<number, CachedTile>,
+    baseBlob: Blob,
+    baseBlobEtag: string,
+    chunk: { x: number; y: number },
 ): Promise<Blob> {
     const CANVAS_SIZE = 1000;
     const RESCALE_FACTOR = 3; // 3x3 pixel size
@@ -36,44 +43,94 @@ export async function renderSquares(
             };
         }),
     );
-    const chunkOverlays = expandedOverlays.filter((overlay) => {
-        if (overlay.hidden) return false;
-        const greaterThanMin = chunkX >= overlay.chunk[0] && chunkY >= overlay.chunk[1];
-        const smallerThanMax = chunkX <= overlay.toChunkX && chunkY <= overlay.toChunkY;
-        return greaterThanMin && smallerThanMax;
-    });
+    const chunkOverlays = expandedOverlays
+        .filter((overlay) => {
+            if (overlay.hidden) return false;
+            const greaterThanMin = chunk.x >= overlay.chunk[0] && chunk.y >= overlay.chunk[1];
+            const smallerThanMax = chunk.x <= overlay.toChunkX && chunk.y <= overlay.toChunkY;
+            return greaterThanMin && smallerThanMax;
+        })
+        .map((overlay) => {
+            const chunkXIndex = overlay.toChunkX - overlay.chunk[0] - (overlay.toChunkX - chunk.x);
+            const chunkYIndex = overlay.toChunkY - overlay.chunk[1] - (overlay.toChunkY - chunk.y);
 
-    if (chunkOverlays.length === 0)
+            let colorFilter: ColorValue[] | undefined;
+            if (overlay.onlyShowSelectedColors) {
+                colorFilter = overlay.colorSelection.map((color) => {
+                    const freeColor = FreeColorMap.get(color as keyof typeof FreeColor);
+                    if (freeColor) {
+                        return freeColor;
+                    } else {
+                        return PaidColorMap.get(color as keyof typeof PaidColor)!;
+                    }
+                });
+            }
+
+            return {
+                ...overlay,
+                chunkXIndex,
+                chunkYIndex,
+                colorFilter,
+            };
+        });
+
+    if (chunkOverlays.length === 0) {
+        console.log("tile has no overlay at", chunk);
         return baseBlob;
+    }
 
+    const encoder = new TextEncoder();
+    const toHexString = (bytes: Uint8Array) =>
+        bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, "0"), "");
+
+    const overlayHashes = await Promise.all(
+        chunkOverlays.map(async (overlay) => {
+            const [imageHashBuffer, colorFilterHashBuffer] = await Promise.all([
+                crypto.subtle.digest("SHA-1", encoder.encode(overlay.image)),
+                overlay.colorFilter
+                    ? crypto.subtle.digest("SHA-1", encoder.encode(overlay.colorFilter.join("")))
+                    : Promise.resolve(null),
+            ]);
+
+            const imageHash = toHexString(new Uint8Array(imageHashBuffer));
+            const colorFilterHash = colorFilterHashBuffer
+                ? toHexString(new Uint8Array(colorFilterHashBuffer))
+                : "nofilter";
+
+            return `${overlay.name},${imageHash},${colorFilterHash},${overlay.toChunkX},${overlay.toChunkY},${overlay.chunkXIndex},${overlay.chunkYIndex},${overlay.coordinate[0]},${overlay.coordinate[1]}`;
+        }),
+    );
+
+    const chunkOverlaysHash = overlayHashes.join("|");
+
+    const tileCacheKey = chunk.x * 100_000 + chunk.y;
+    let cachedTile = tilesCache.get(tileCacheKey) || ({} as CachedTile);
+    if (
+        cachedTile &&
+        cachedTile.baseBlobEtag === baseBlobEtag &&
+        cachedTile.overlaysHash === chunkOverlaysHash
+    ) {
+        console.log("tile was served from cache at", chunk);
+        return cachedTile.blob;
+    }
+
+    console.log("rendering overlay to tile at", chunk);
     const renderingCanvas = new CustomCanvas(RESCALED_CANVAS_SIZE);
 
     const img = await createImageBitmap(baseBlob);
     renderingCanvas.ctx.drawImage(img, 0, 0, RESCALED_CANVAS_SIZE, RESCALED_CANVAS_SIZE);
 
     for (const overlay of chunkOverlays) {
-        const chunkXIndex = overlay.toChunkX - overlay.chunk[0] - (overlay.toChunkX - chunkX);
-        const chunkYIndex = overlay.toChunkY - overlay.chunk[1] - (overlay.toChunkY - chunkY);
-
-        let colorFilter: ColorValue[] | undefined;
-
-        if (overlay.onlyShowSelectedColors) {
-            colorFilter = overlay.colorSelection.map((color) => {
-                const freeColor = FreeColorMap.get(color as keyof typeof FreeColor);
-                if (freeColor) {
-                    return freeColor;
-                } else {
-                    return PaidColorMap.get(color as keyof typeof PaidColor)!;
-                }
-            });
-        }
-
-        const templateBitmap = await createTemplateBitmap(overlay.bitmap!, RESCALE_FACTOR, colorFilter);
+        const templateBitmap = await createTemplateBitmap(
+            overlay.bitmap!,
+            RESCALE_FACTOR,
+            overlay.colorFilter,
+        );
 
         renderingCanvas.ctx.drawImage(
             templateBitmap,
-            overlay.coordinate[0] * RESCALE_FACTOR - chunkXIndex * RESCALED_CANVAS_SIZE,
-            overlay.coordinate[1] * RESCALE_FACTOR - chunkYIndex * RESCALED_CANVAS_SIZE,
+            overlay.coordinate[0] * RESCALE_FACTOR - overlay.chunkXIndex * RESCALED_CANVAS_SIZE,
+            overlay.coordinate[1] * RESCALE_FACTOR - overlay.chunkYIndex * RESCALED_CANVAS_SIZE,
             templateBitmap.width,
             templateBitmap.height,
         );
@@ -85,6 +142,12 @@ export async function renderSquares(
 
     renderingCanvas.destroy();
 
+    cachedTile.blob = blob;
+    cachedTile.baseBlobEtag = baseBlobEtag;
+    cachedTile.overlaysHash = chunkOverlaysHash;
+    tilesCache.set(tileCacheKey, cachedTile);
+
+    console.log("redered and cached overlay to tile at", chunk);
     return blob;
 }
 

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,6 @@
+/**
+ * @param ms - The number of milliseconds to sleep.
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
I added caching for rendered overlay-tiles. This prevents re-rendering the overlay if nothing has changed on the original tile image and/or the template settings. The cache respects changes to the template images and/or its color filter.
What i also did is revert to the injected fetch hook, because the previous hooking method did not work on safari (couldn't figure out why exactly).
I also fixed #33 which was caused from centering the overlay jump and wplace seems to care about integer only coordinates now.
Feel free to remove the logs i added, they just helped me alot to debug whats going on.
